### PR TITLE
Drop obsolete INJECTOR_VERSION / INJECTOR_AMD64_SHASUM --set flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,6 @@ lint:
 	--set PROXY_IMAGE_DOMAIN="registry1.dso.mil/" \
 	--set PROXY_IMAGE="ironbank/opensource/alpine/socat/socat" \
 	--set PROXY_IMAGE_TAG=$(PROXY_VERSION) \
-	--set INJECTOR_VERSION="2025-03-24" \
-	--set INJECTOR_AMD64_SHASUM="a78d66b9e2b00a22edd9b4e6432a4d934621e3757f09493b12f688c7c9baca93" \
 	--set GITEA_IMAGE=registry1.dso.mil/ironbank/opensource/go-gitea/gitea:v$(GITEA_VERSION)
 
 build:
@@ -40,8 +38,6 @@ build:
 	--set PROXY_IMAGE_DOMAIN="registry1.dso.mil/" \
 	--set PROXY_IMAGE="ironbank/opensource/alpine/socat/socat" \
 	--set PROXY_IMAGE_TAG=$(PROXY_VERSION) \
-	--set INJECTOR_VERSION="2025-03-24" \
-	--set INJECTOR_AMD64_SHASUM="a78d66b9e2b00a22edd9b4e6432a4d934621e3757f09493b12f688c7c9baca93" \
 	--set GITEA_IMAGE=registry1.dso.mil/ironbank/opensource/go-gitea/gitea:v$(GITEA_VERSION)
 
 generate-key-pair:


### PR DESCRIPTION
## Summary

- Removes the `--set INJECTOR_VERSION=...` and `--set INJECTOR_AMD64_SHASUM=...` flags from both the `lint` and `build` Makefile targets.
- These template variables no longer exist in upstream `zarf-dev/zarf` starting with v0.78.0 — the injector binary was split into its own repo (`zarf-dev/zarf-injector`) and the upstream `packages/zarf-registry/zarf.yaml` now hardcodes the source URL, version, and shasum.
- The flags were silently ignored by current zarf (which only errors on *missing* template vars, not extra `--set` flags), so this is dead-code cleanup.

Closes #95.

## ⚠️ Merge order

This PR is **blocked on #78** (`Update dependency zarf-dev/zarf to v0.78.0`). Today's `main` still imports `init:v0.60.0`, where the injector templates *do* exist. Removing the `--set` flags before #78 lands will re-break `make lint` on `main`.

CI on this branch will fail until #78 is merged and this branch is rebased onto the updated `main`. **Do not merge this PR until #78 is in `main`.**

Related: #94 (the PROXY_IMAGE_TAG fix that unblocked the v0.78.0 bump in #78) — already merged.

## Test plan

- [ ] After #78 merges, rebase this branch on `main`
- [ ] Confirm CI (`Test packaging` → `build`) goes green
- [ ] `make lint` and `make build` succeed locally without warnings about unknown `--set` keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)